### PR TITLE
Detect cycles, change internal tf representation, expose all_frames_as_map method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@
 //!     }
 //! }
 //!```
-use rosrust_msg::geometry_msgs::{Transform, TransformStamped};
+#[allow(unused_imports)]
+use rosrust_msg::geometry_msgs::{Transform, TransformStamped, Quaternion, Vector3};
 use rosrust_msg::std_msgs::Header;
 use rosrust_msg::tf2_msgs::TFMessage;
 use std::cmp::Ordering;
@@ -54,7 +55,7 @@ impl PartialOrd for OrderedTF {
 /// Calculates the inverse of a ros transform
 
 /// Enumerates the different types of errors
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum TfError {
     /// Error due to looking up too far in the past. I.E the information is no longer available in the TF Cache.
     AttemptedLookupInPast,
@@ -173,6 +174,18 @@ impl TfIndividualTransformChain {
     }
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct Node {
+    pub parent: String,
+    #[allow(dead_code)]
+    pub broadcaster: String,
+    pub rate: f64,
+    pub most_recent_transform: f64,
+    pub oldest_transform: f64,
+    #[allow(dead_code)]
+    pub buffer_length: f64,
+}
+
 #[derive(Clone, Debug, Hash)]
 struct TfGraphNode {
     child: String,
@@ -188,7 +201,7 @@ impl PartialEq for TfGraphNode {
 impl Eq for TfGraphNode {}
 
 #[derive(Clone, Debug)]
-struct TfBuffer {
+pub struct TfBuffer {
     child_transform_index: HashMap<String, HashSet<String>>,
     transform_data: HashMap<TfGraphNode, TfIndividualTransformChain>,
 }
@@ -214,29 +227,57 @@ impl TfBuffer {
         for mut transform in transforms.transforms {
             strip_leading_slash(&mut transform);
             self.add_transform(&transform, static_tf);
-            self.add_transform(&transforms::get_inverse(&transform), static_tf);
         }
+    }
+    
+
+    fn creates_cycle(&self, parent: &String, child: &String) -> bool {
+        let mut visited = HashSet::new();
+        let mut stack = VecDeque::new();
+        stack.push_back(child.clone());
+
+        while let Some(node) = stack.pop_back() {
+            if &node == parent {
+                return true;
+            }
+            if visited.contains(&node) {
+                continue;
+            }
+            visited.insert(node.clone());
+
+            if let Some(children) = self.child_transform_index.get(&node) {
+                for child in children {
+                    if !visited.contains(child) {
+                        stack.push_back(child.clone());
+                    }
+                }
+            }
+        }
+        false
     }
 
     fn add_transform(&mut self, transform: &TransformStamped, static_tf: bool) {
-        //TODO: Detect is new transform will create a loop
-        if self
-            .child_transform_index
-            .contains_key(&transform.header.frame_id)
-        {
-            let res = self
+        if !self.creates_cycle(&transform.header.frame_id.clone(), &transform.child_frame_id) {
+            if self
                 .child_transform_index
-                .get_mut(&transform.header.frame_id.clone())
-                .unwrap();
-            res.insert(transform.child_frame_id.clone());
+                .contains_key(&transform.header.frame_id)
+            {
+                let res = self
+                    .child_transform_index
+                    .get_mut(&transform.header.frame_id.clone())
+                    .unwrap();
+                res.insert(transform.child_frame_id.clone());
+            } else {
+                self.child_transform_index
+                    .insert(transform.header.frame_id.clone(), HashSet::new());
+                let res = self
+                    .child_transform_index
+                    .get_mut(&transform.header.frame_id.clone())
+                    .unwrap();
+                res.insert(transform.child_frame_id.clone());
+            }
         } else {
-            self.child_transform_index
-                .insert(transform.header.frame_id.clone(), HashSet::new());
-            let res = self
-                .child_transform_index
-                .get_mut(&transform.header.frame_id.clone())
-                .unwrap();
-            res.insert(transform.child_frame_id.clone());
+            return
         }
 
         let key = TfGraphNode {
@@ -253,48 +294,75 @@ impl TfBuffer {
             self.transform_data.insert(key, data);
         }
     }
-
-    /// Retrieves the transform path
-    fn retrieve_transform_path(&self, from: String, to: String) -> Result<Vec<String>, TfError> {
-        let mut res = vec![];
-        let mut frontier: VecDeque<String> = VecDeque::new();
-        let mut visited: HashSet<String> = HashSet::new();
-        let mut parents: HashMap<String, String> = HashMap::new();
-        visited.insert(from.clone());
-        frontier.push_front(from.clone());
-
-        while !frontier.is_empty() {
-            let current_node = frontier.pop_front().unwrap();
-            if current_node == to {
-                break;
+    
+    fn create_child_to_parent_map(&self) -> HashMap<String, String> {
+        let mut child_to_parent: HashMap<String, String> = HashMap::new();
+        
+        for (parent, children) in self.child_transform_index.iter() {
+            for child in children {
+                child_to_parent.insert(child.clone(), parent.clone());
             }
-            let children = self.child_transform_index.get(&current_node);
-            match children {
-                Some(children) => {
-                    for v in children {
-                        if visited.contains(&v.to_string()) {
-                            continue;
-                        }
-                        parents.insert(v.to_string(), current_node.clone());
-                        frontier.push_front(v.to_string());
-                        visited.insert(v.to_string());
-                    }
+        }
+        
+        child_to_parent
+    }
+
+    fn retrieve_transform_path(&self, source_frame_id: String, target_frame_id: String) -> Result<(Vec<String>, Vec<String>), TfError> {
+        let child_to_parent = self.create_child_to_parent_map();
+
+        let trace_to_root_or_goal = |node: String, goal: Option<String>,child_to_parent: &HashMap<String, String>| -> Result<Vec<String>, TfError> {
+            let mut path = vec![];
+            let mut current = node;
+
+            while let Some(parent) = child_to_parent.get(&current) {
+                path.push(current.clone());
+                if goal.clone().is_some() && current == goal.clone().unwrap(){
+                    path.reverse();
+                    return Ok(path);
                 }
-                None => {}
+                current = parent.clone();
             }
-        }
-        let mut r = to;
-        while r != from {
-            res.push(r.clone());
-            let parent = parents.get(&r);
+            path.push(current.clone()); // Add the last node (root)
+            path.reverse();
+            Ok(path)
+        };
 
-            match parent {
-                Some(x) => r = x.to_string(),
-                None => return Err(TfError::CouldNotFindTransform),
-            }
+        let path_from_source = trace_to_root_or_goal(source_frame_id.clone(), Some(target_frame_id.clone()), &child_to_parent)?;
+        let path_to_target = trace_to_root_or_goal(target_frame_id.clone(), Some(source_frame_id.clone()), &child_to_parent)?;
+        
+        // We are in a same subtree
+        if let Some(pos) = path_to_target.iter().position(|x| x == &source_frame_id) {
+            return Ok((Vec::new(), path_to_target[pos + 1..].to_vec()));
+        } 
+        if let Some(pos) = path_from_source.iter().position(|x| x == &target_frame_id) {
+            let mut ans = path_from_source[pos..].to_vec();
+            ans.reverse();
+            return Ok((ans[1..].to_vec(), Vec::new()));
         }
-        res.reverse();
-        Ok(res)
+
+        let mut lowest_common_ancestor = path_from_source.iter()
+            .zip(&path_to_target)
+            .take_while(|(a, b)| a == b)
+            .count();
+
+        if lowest_common_ancestor == 0 {
+            return Err(TfError::CouldNotFindTransform);
+        }
+        lowest_common_ancestor = lowest_common_ancestor - 1;
+
+        // Concatenate paths: source_frame_id -> LCA -> target_frame_id
+        let mut final_path_to_target = Vec::new();
+        let mut final_path_from_source = Vec::new();
+        for i in (lowest_common_ancestor..path_from_source.len()-1).rev() {
+            final_path_from_source.push(path_from_source[i].clone());
+        }
+
+        // From the LCA to 'target_frame_id', exclusive of the LCA
+        for i in lowest_common_ancestor+1..path_to_target.len() {
+            final_path_to_target.push(path_to_target[i].clone());
+        }
+
+        Ok((final_path_from_source, final_path_to_target))
     }
 
     /// Looks up a transform within the tree at a given time.
@@ -304,43 +372,51 @@ impl TfBuffer {
         to: &str,
         time: rosrust::Time,
     ) -> Result<TransformStamped, TfError> {
-        let from = from.to_string();
-        let to = to.to_string();
-        let path = self.retrieve_transform_path(from.clone(), to.clone());
+        let path = self.retrieve_transform_path(from.to_string(), to.to_string())?;
+        let mut tflist = Vec::new();
+        let mut prev_frame_id = from;
+    
+        let (path_from, path_to) = path;
+    
+        for (index, _) in path_from.iter().chain(&path_to).enumerate() {
+            let inverse_needed = index < path_from.len();
 
-        match path {
-            Ok(path) => {
-                let mut tflist: Vec<Transform> = Vec::new();
-                let mut first = from.clone();
-                for intermediate in path {
-                    let node = TfGraphNode {
-                        child: intermediate.clone(),
-                        parent: first.clone(),
-                    };
-                    let time_cache = self.transform_data.get(&node).unwrap();
-                    let transform = time_cache.get_closest_transform(time);
-                    match transform {
-                        Err(e) => return Err(e),
-                        Ok(x) => {
-                            tflist.push(x.transform);
-                        }
-                    }
-                    first = intermediate.clone();
-                }
-                let final_tf = transforms::chain_transforms(&tflist);
-                let msg = TransformStamped {
-                    child_frame_id: to.clone(),
-                    header: Header {
-                        frame_id: from.clone(),
-                        stamp: time,
-                        seq: 1,
-                    },
-                    transform: final_tf,
-                };
-                return Ok(msg);
-            }
-            Err(x) => return Err(x),
-        };
+            let (parent, child, new_prev) = if inverse_needed {
+                (path_from[index].as_str(), prev_frame_id, path_from[index].as_str())
+            } else {
+                (prev_frame_id, path_to[index - path_from.len()].as_str(), path_to[index - path_from.len()].as_str())
+            };
+            prev_frame_id = new_prev;
+
+            let node = TfGraphNode {
+                parent: parent.to_string(),
+                child: child.to_string(),
+            };
+    
+            let transform = self.transform_data.get(&node)
+                .ok_or_else(|| TfError::CouldNotFindTransform)      
+                .and_then(|tc| tc.get_closest_transform(time))?;
+    
+            let transform = if inverse_needed {
+                transforms::get_inverse(&transform)
+            } else {
+                transform
+            };
+    
+            tflist.push(transform.transform);
+        }
+    
+        let final_transform = transforms::chain_transforms(&tflist);
+    
+        Ok(TransformStamped {
+            child_frame_id: to.to_string(),
+            header: Header {
+                frame_id: from.to_string(),
+                stamp: time,
+                seq: 1,
+            },
+            transform: final_transform,
+        })
     }
 
     fn lookup_transform_with_time_travel(
@@ -371,129 +447,221 @@ impl TfBuffer {
             time1,
         ))
     }
+
+    pub fn all_frames_as_map(&self)->HashMap<String, Node>{
+        let child_to_parent = self.create_child_to_parent_map();
+
+        let mut frames: HashMap<String, Node> = HashMap::new();
+        for (child, parent) in child_to_parent {
+            let node = TfGraphNode {
+                parent: parent.to_string(),
+                child: child.to_string(),
+            };
+            let transform = self.transform_data.get(&node)
+                .ok_or_else(|| TfError::CouldNotFindTransform)      
+                .and_then(|tc| tc.get_closest_transform(rosrust::Time::new()))
+                .unwrap();
+
+            let time = transform.header.stamp.sec as f64 + (transform.header.stamp.nsec as f64 / 1_000_000_000.0);
+            
+            // TODO some fields are placeholder values here
+            // such as rate, broadcaster, oldest_transform, buffer_length
+            frames.insert(
+                child,
+                Node {
+                    parent: parent,
+                    broadcaster: "unknown_publisher".to_string(),
+                    rate: 0.0,
+                    most_recent_transform: time,
+                    oldest_transform: time,
+                    buffer_length: 0.0,
+                }
+            );
+        }
+
+        return frames;
+
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    /// This function builds a tree consisting of the following items:
-    /// * a world coordinate frame
-    /// * an item in the world frame at (1,0,0)
-    /// * base_link of a robot starting at (0,0,0) and progressing at (0,t,0) where t is time in seconds
-    /// * a camera which is (0.5, 0, 0) from the base_link
-    fn build_test_tree(buffer: &mut TfBuffer, time: f64) {
+
+    fn create_transform(frame_id: &str, child_frame_id: &str, x: f64, y: f64, z: f64, w: f64, tx: f64, ty: f64, tz: f64, time: f64) -> TransformStamped {
+        let secs = time.floor() as u32;
         let nsecs = ((time - ((time.floor() as i64) as f64)) * 1E9) as u32;
 
-        let world_to_item = TransformStamped {
-            child_frame_id: "item".to_string(),
+        TransformStamped {
+            child_frame_id: child_frame_id.to_string(),
             header: Header {
-                frame_id: "world".to_string(),
-                stamp: rosrust::Time {
-                    sec: time.floor() as u32,
-                    nsec: nsecs,
-                },
+                frame_id: frame_id.to_string(),
+                stamp: rosrust::Time { sec: secs, nsec: nsecs },
                 seq: 1,
             },
             transform: Transform {
-                rotation: Quaternion {
-                    x: 0f64,
-                    y: 0f64,
-                    z: 0f64,
-                    w: 1f64,
-                },
-                translation: Vector3 {
-                    x: 1f64,
-                    y: 0f64,
-                    z: 0f64,
-                },
+                rotation: Quaternion { x, y, z, w },
+                translation: Vector3 { x: tx, y: ty, z: tz },
             },
-        };
-        buffer.add_transform(&world_to_item, true);
-        buffer.add_transform(&transforms::get_inverse(&world_to_item), true);
-
-        let world_to_base_link = TransformStamped {
-            child_frame_id: "base_link".to_string(),
-            header: Header {
-                frame_id: "world".to_string(),
-                stamp: rosrust::Time {
-                    sec: time.floor() as u32,
-                    nsec: nsecs,
-                },
-                seq: 1,
-            },
-            transform: Transform {
-                rotation: Quaternion {
-                    x: 0f64,
-                    y: 0f64,
-                    z: 0f64,
-                    w: 1f64,
-                },
-                translation: Vector3 {
-                    x: 0f64,
-                    y: time,
-                    z: 0f64,
-                },
-            },
-        };
-        buffer.add_transform(&world_to_base_link, false);
-        buffer.add_transform(&transforms::get_inverse(&world_to_base_link), false);
-
-        let base_link_to_camera = TransformStamped {
-            child_frame_id: "camera".to_string(),
-            header: Header {
-                frame_id: "base_link".to_string(),
-                stamp: rosrust::Time {
-                    sec: time.floor() as u32,
-                    nsec: nsecs,
-                },
-                seq: 1,
-            },
-            transform: Transform {
-                rotation: Quaternion {
-                    x: 0f64,
-                    y: 0f64,
-                    z: 0f64,
-                    w: 1f64,
-                },
-                translation: Vector3 {
-                    x: 0.5f64,
-                    y: 0f64,
-                    z: 0f64,
-                },
-            },
-        };
-        buffer.add_transform(&base_link_to_camera, true);
-        buffer.add_transform(&get_inverse(&base_link_to_camera), true);
+        }
     }
 
-    /// Tests a basic lookup
+    /// Final TF Tree
+    ///
+    /// world/
+    /// ├─ item/
+    /// │  ├─ item_link_1/
+    /// │  │  ├─ item_link_2/
+    /// ├─ base_link(starting at (0,0,0) and progressing at (0,t,0) where t is time in seconds)/
+    /// │  ├─ camera/
+    /// │  ├─ sensor_base/
+    /// │     ├─ sensor_base/
+    /// │  ├─ f_r_wheel/
+    /// │  ├─ r_r_wheel/
+    /// │  ├─ r_l_wheel/
+    /// │  ├─ f_l_wheel/
+    fn build_test_tree(buffer: &mut TfBuffer, time: f64) {
+        let world_to_item = create_transform("world", "item", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&world_to_item, true);
+
+        let item_to_item_link1 = create_transform("item", "item_link_1", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&item_to_item_link1, true);
+
+        let item_link1_to_item_link2 = create_transform("item_link_1", "item_link_2", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&item_link1_to_item_link2, true);
+
+        let world_to_base_link = create_transform("world", "base_link", 0.0, 0.0, 0.0, 1.0, 0.0, time, 0.0, time);
+        buffer.add_transform(&world_to_base_link, false);
+
+        let base_link_to_camera = create_transform("base_link", "camera", 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, time);
+        buffer.add_transform(&base_link_to_camera, true);
+
+
+        let base_link_to_f_r_wheel = create_transform("base_link", "f_r_wheel", 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, time);
+        buffer.add_transform(&base_link_to_f_r_wheel, true);
+        let base_link_to_f_l_wheel = create_transform("base_link", "f_l_wheel", 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, time);
+        buffer.add_transform(&base_link_to_f_l_wheel, true);
+        let base_link_to_r_r_wheel = create_transform("base_link", "r_r_wheel", 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, time);
+        buffer.add_transform(&base_link_to_r_r_wheel, true);
+        let base_link_to_r_l_wheel = create_transform("base_link", "r_l_wheel", 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0, time);
+        buffer.add_transform(&base_link_to_r_l_wheel, true);
+
+        let base_link_to_sensor_base = create_transform("base_link", "sensor_base", 0.707, 0.0, 0.0, 0.707, 0.5, 0.0, 0.0, time);
+        buffer.add_transform(&base_link_to_sensor_base, true);
+        let sensor_base_to_sensor = create_transform("sensor_base", "sensor", -0.707, 0.0, 0.0, 0.707, 0.0, 0.0, 0.0, time);
+        buffer.add_transform(&sensor_base_to_sensor, true);
+    }
+    /// world/
+    /// ├─ item/
+    fn build_small_test_tree(buffer: &mut TfBuffer, time: f64) {
+        let world_to_item = create_transform("world", "item", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&world_to_item, true);
+    }
+    
+    #[test]
+    fn test_cycle() {
+        let time = 0f64;
+        let mut buffer = TfBuffer::new();
+        let world_to_item = create_transform("world", "item", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&world_to_item, true);
+
+        let item_to_item2 = create_transform("item", "item_2", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&item_to_item2, true);
+
+        let item_to_item3 = create_transform("item", "item_3", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&item_to_item3, true);
+
+        assert_eq!(buffer.child_transform_index.keys().len(), 2);
+        assert_eq!(buffer.child_transform_index["item"].len(), 2);
+
+        let item_to_world = create_transform("item", "world", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&item_to_world, true);
+
+        let item3_to_world = create_transform("item_3", "world", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, time);
+        buffer.add_transform(&item3_to_world, true);
+
+        assert_eq!(buffer.child_transform_index.keys().len(), 2);
+        assert_eq!(buffer.child_transform_index["item"].len(), 2);
+    }
+
+    #[test]
+    fn test_get_all_frames() {
+        let time = 0f64;
+        let mut tf_buffer = TfBuffer::new();
+        build_test_tree(&mut tf_buffer, time);
+
+        let frames = tf_buffer.all_frames_as_map();
+        let nodes_data = vec![
+            ("r_r_wheel", "base_link"),
+            ("sensor_base", "base_link"),
+            ("camera", "base_link"),
+            ("item", "world"),
+            ("r_l_wheel", "base_link"),
+            ("sensor", "sensor_base"),
+            ("item_link_1", "item"),
+            ("item_link_2", "item_link_1"),
+            ("f_l_wheel", "base_link"),
+            ("base_link", "world"),
+            ("f_r_wheel", "base_link"),
+        ];
+
+        let expected: HashMap<String, Node> = nodes_data
+            .into_iter()
+            .map(|(name, parent)| {
+                (
+                    name.to_string(),
+                    Node {
+                        parent: parent.to_string(),
+                        broadcaster: "unknown_publisher".to_string(),
+                        rate: 0.0,
+                        most_recent_transform: time,
+                        oldest_transform: time,
+                        buffer_length: 0.0,
+                    },
+                )
+            })
+            .collect();
+        
+        assert_eq!(frames, expected);
+    }
     #[test]
     fn test_basic_tf_lookup() {
+        let time = 0f64;
         let mut tf_buffer = TfBuffer::new();
-        build_test_tree(&mut tf_buffer, 0f64);
-        let res = tf_buffer.lookup_transform("camera", "item", rosrust::Time { sec: 0, nsec: 0 });
-        let expected = TransformStamped {
-            child_frame_id: "item".to_string(),
-            header: Header {
-                frame_id: "camera".to_string(),
-                stamp: rosrust::Time { sec: 0, nsec: 0 },
-                seq: 1,
-            },
-            transform: Transform {
-                rotation: Quaternion {
-                    x: 0f64,
-                    y: 0f64,
-                    z: 0f64,
-                    w: 1f64,
-                },
-                translation: Vector3 {
-                    x: 0.5f64,
-                    y: 0f64,
-                    z: 0f64,
-                },
-            },
-        };
-        assert_eq!(res.unwrap(), expected);
+        build_test_tree(&mut tf_buffer, time);
+
+        let test_cases = [
+            ("r_l_wheel", "world", 0.0, 0.0, 0.0, 1.0, -0.5, 0.0, 0.0),
+            ("r_l_wheel", "item_link_1", 0.0, 0.0, 0.0, 1.0, 1.5, 0.0, 0.0),
+            ("item_link_2", "item", 0.0, 0.0, 0.0, 1.0, -2.0, 0.0, 0.0),
+            ("item", "item", 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0),
+            ("camera", "f_l_wheel", 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0),
+            ("world", "sensor_base", 0.707, 0.0, 0.0, 0.707, 0.5, 0.0, 0.0),
+            ("world", "sensor", 0.0, 0.0, 0.0, 1.0, 0.5, 0.0, 0.0),
+        ];
+
+        for (from, to, x, y, z, w, tx, ty, tz) in test_cases.iter() {
+            let result = tf_buffer.lookup_transform(from, to, rosrust::Time { sec: 0, nsec: 0 });
+            let expected = create_transform(from, to, *x, *y, *z, *w, *tx, *ty, *tz, time);
+            assert_approx_eq(result.unwrap(), expected );
+        }
+
+        tf_buffer = TfBuffer::new();
+        build_small_test_tree(&mut tf_buffer, time);
+        let test_cases = [
+            ("world", "item", 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0)
+        ];
+        for (from, to, x, y, z, w, tx, ty, tz) in test_cases.iter() {
+            let result = tf_buffer.lookup_transform(from, to, rosrust::Time { sec: 0, nsec: 0 });
+            let expected = create_transform(from, to, *x, *y, *z, *w, *tx, *ty, *tz, time);
+            assert_approx_eq(result.unwrap(), expected );
+        }
+        let result = tf_buffer.lookup_transform("void1", "void2", rosrust::Time { sec: 0, nsec: 0 });
+        assert_eq!(result, Err(TfError::CouldNotFindTransform));
+
+        tf_buffer = TfBuffer::new();
+        let result = tf_buffer.lookup_transform("void1", "void2", rosrust::Time { sec: 0, nsec: 0 });
+        assert_eq!(result, Err(TfError::CouldNotFindTransform));
     }
 
     /// Tests an interpolated lookup.
@@ -564,7 +732,7 @@ mod test {
                     sec: 0,
                     nsec: 700_000_000,
                 },
-                seq: 0,
+                seq: 1,
             },
             transform: Transform {
                 rotation: Quaternion {
@@ -587,14 +755,14 @@ mod test {
         assert_eq!(msg1.header, msg2.header);
         assert_eq!(msg1.child_frame_id, msg2.child_frame_id);
 
-        assert!((msg1.transform.rotation.x - msg2.transform.rotation.x).abs() < 1e-9);
-        assert!((msg1.transform.rotation.y - msg2.transform.rotation.y).abs() < 1e-9);
-        assert!((msg1.transform.rotation.z - msg2.transform.rotation.z).abs() < 1e-9);
-        assert!((msg1.transform.rotation.w - msg2.transform.rotation.w).abs() < 1e-9);
+        assert!((msg1.transform.rotation.x - msg2.transform.rotation.x).abs() < 1e-3, "left {} right {}", msg1.transform.rotation.x, msg2.transform.rotation.x);
+        assert!((msg1.transform.rotation.y - msg2.transform.rotation.y).abs() < 1e-3, "left {} right {}", msg1.transform.rotation.y, msg2.transform.rotation.y);
+        assert!((msg1.transform.rotation.z - msg2.transform.rotation.z).abs() < 1e-3, "left {} right {}", msg1.transform.rotation.z, msg2.transform.rotation.z);
+        assert!((msg1.transform.rotation.w - msg2.transform.rotation.w).abs() < 1e-3, "left {} right {}", msg1.transform.rotation.w, msg2.transform.rotation.w);
 
-        assert!((msg1.transform.translation.x - msg2.transform.translation.x).abs() < 1e-9);
-        assert!((msg1.transform.translation.y - msg2.transform.translation.y).abs() < 1e-9);
-        assert!((msg1.transform.translation.z - msg2.transform.translation.z).abs() < 1e-9);
+        assert!((msg1.transform.translation.x - msg2.transform.translation.x).abs() < 1e-4, "left {} right {}", msg1.transform.translation.x, msg2.transform.translation.x);
+        assert!((msg1.transform.translation.y - msg2.transform.translation.y).abs() < 1e-4, "left {} right {}", msg1.transform.translation.y, msg2.transform.translation.y);
+        assert!((msg1.transform.translation.z - msg2.transform.translation.z).abs() < 1e-4, "left {} right {}", msg1.transform.translation.z, msg2.transform.translation.z);
     }
 }
 
@@ -618,7 +786,7 @@ mod test {
 /// Do note that unlike the C++ variant of the TfListener, only one TfListener can be created at a time. Like its C++ counterpart,
 /// it must be scoped to exist through the lifetime of the program. One way to do this is using an `Arc` or `RwLock`.
 pub struct TfListener {
-    buffer: Arc<RwLock<TfBuffer>>,
+    pub buffer: Arc<RwLock<TfBuffer>>,
     _static_subscriber: rosrust::Subscriber,
     _dynamic_subscriber: rosrust::Subscriber,
 }

--- a/src/transforms.rs
+++ b/src/transforms.rs
@@ -129,7 +129,7 @@ mod test {
             translation: Vector3{x: 2f64, y: 2f64, z: 0f64},
             rotation: Quaternion{x: 0f64, y: 0f64, z: 0f64, w: 1f64}
         };
-        let transform_chain = vec!(tf1, tf1);
+        let transform_chain = vec!(tf1.clone(), tf1);
         let res = chain_transforms(&transform_chain);
         assert_eq!(res, expected_tf);
     }


### PR DESCRIPTION
Two major changes:
1. Before adding a new frame with `add_transform`, we now check if it creates a cycle in the tree.
2. Completely changed the internal tf representation to a more tree-like structure, inspired by the original ros tf library. This change eliminates duplicates in the hashmap and removes the need to add transforms for inverted pairs. The API remains unchanged for the end-user, but this update allows us to expose functions like `all_frames_as_map` and enables more granular frame manipulation.


This is required for https://github.com/carzum/termviz/pull/96 to not depend on any external service. It's a big change so it is the impact, I tried to cover every test case in test(please tell me if I forgot about some), but in my opinion this is needed as original representation wasn't complete.